### PR TITLE
german title.txt

### DIFF
--- a/fastlane/metadata/android/de-DE/title.txt
+++ b/fastlane/metadata/android/de-DE/title.txt
@@ -1,0 +1,1 @@
+Simple Kontakte


### PR DESCRIPTION
I did not translate the word "simple" - completely translated it would be "Einfache Kontakte", but as the App Suite is called "Simple Apps" I would keep it like that, to improve name / brand recognition.