### PR TITLE
improve german translations

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Simple Kontakte</string>
+    <string name="app_name">Schlichte Kontakte</string>
     <string name="app_launcher_name">Kontakte</string>
     <string name="address">Adresse</string>
     <string name="inserting">Einfügen…</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Schlichte Kontakte</string>
+    <string name="app_name">Simple Kontakte</string>
     <string name="app_launcher_name">Kontakte</string>
     <string name="address">Adresse</string>
     <string name="inserting">Einfügen…</string>
@@ -8,11 +8,11 @@
     <string name="phone_storage_hidden">Gerätespeicher (nicht sichtbar für andere Apps)</string>
     <string name="company">Unternehmen</string>
     <string name="job_position">Arbeitsstelle</string>
-    <string name="website">Website</string>
-    <string name="send_sms_to_contacts">Sende SMS zu Kontakten</string>
-    <string name="send_email_to_contacts">Sende E-Mail zu Kontakten</string>
-    <string name="send_sms_to_group">Sende SMS zu Gruppe</string>
-    <string name="send_email_to_group">Sende E-Mail zu Gruppe</string>
+    <string name="website">Webseite</string>
+    <string name="send_sms_to_contacts">Sende SMS an Kontakte</string>
+    <string name="send_email_to_contacts">Sende E-Mail an Kontakte</string>
+    <string name="send_sms_to_group">Sende SMS an Gruppe</string>
+    <string name="send_email_to_group">Sende E-Mail an Gruppe</string>
 
     <string name="new_contact">Neuer Kontakt</string>
     <string name="edit_contact">Kontakt bearbeiten</string>
@@ -20,12 +20,12 @@
     <string name="select_contacts">Kontakte auswählen</string>
     <string name="first_name">Vorname</string>
     <string name="middle_name">Zweiter Vorname</string>
-    <string name="surname">Familienname</string>
+    <string name="surname">Nachname</string>
 
     <!-- Groups -->
     <string name="no_groups">Keine Gruppen</string>
     <string name="create_new_group">Eine neue Gruppe erstellen</string>
-    <string name="remove_from_group">Von Gruppe entfernen</string>
+    <string name="remove_from_group">Aus Gruppe entfernen</string>
     <string name="no_group_participants">Diese Gruppe ist leer</string>
     <string name="add_contacts">Kontakte hinzufügen</string>
     <string name="no_group_created">Es sind keine Kontaktgruppen auf diesem Gerät vorhanden</string>
@@ -34,21 +34,21 @@
     <string name="create_group_under_account">Gruppe in diesem Konto erstellen</string>
 
     <!-- Photo -->
-    <string name="take_photo">Foto machen</string>
+    <string name="take_photo">Foto aufnehmen</string>
     <string name="choose_photo">Foto auswählen</string>
     <string name="remove_photo">Foto entfernen</string>
 
     <!-- Settings -->
     <string name="start_name_with_surname">Namen mit Nachnamen beginnen</string>
     <string name="show_phone_numbers">Zeige Telefonnummern im Hauptmenü</string>
-    <string name="show_contact_thumbnails">Zeige Vorschaubilder für Kontakte</string>
+    <string name="show_contact_thumbnails">Zeige Vorschaubilder der Kontakte</string>
     <string name="on_contact_click">Beim Klicken auf den Kontakt</string>
     <string name="call_contact">Kontakt anrufen</string>
-    <string name="view_contact">Kontaktdetails ansehen</string>
-    <string name="show_favorites_tab">Zeige Favoriten</string>
-    <string name="show_groups_tab">Zeige Gruppen</string>
+    <string name="view_contact">Kontaktdetails anzeigen</string>
+    <string name="show_favorites_tab">Zeige Favoriten-Reiter</string>
+    <string name="show_groups_tab">Zeige Gruppen-Reiter</string>
     <string name="manage_shown_contact_fields">Bearbeite sichtbare Kontaktfelder</string>
-    <string name="filter_duplicates">Versuche Kontaktdupplikate herauszufiltern</string>
+    <string name="filter_duplicates">Versuche Kontaktduplikate herauszufiltern</string>
 
     <!-- Emails -->
     <string name="email">E-Mail</string>
@@ -74,7 +74,7 @@
     <string name="add_favorites">Favoriten hinzufügen</string>
     <string name="add_to_favorites">Zu Favoriten hinzufügen</string>
     <string name="remove_from_favorites">Aus Favoriten entfernen</string>
-    <string name="must_be_at_edit">Sie müssen sich im Editier-Modus befinden, um einen Kontakt zu bearbeiten</string>
+    <string name="must_be_at_edit">Sie müssen sich im Bearbeitungsmodus befinden, um einen Kontakt zu bearbeiten</string>
 
     <!-- Search -->
     <string name="search_contacts">Kontakte durchsuchen</string>
@@ -90,8 +90,8 @@
     <string name="filename_without_vcf">Dateiname (ohne .vcf)</string>
 
     <!-- Visible fields -->
-    <string name="select_fields_to_show">Sichtbare Felder selektieren</string>
-    <string name="prefix">Prefix</string>
+    <string name="select_fields_to_show">Sichtbare Felder auswählen</string>
+    <string name="prefix">Titel</string>
     <string name="suffix">Suffix</string>
     <string name="phone_numbers">Telefonnummern</string>
     <string name="emails">E-Mails</string>
@@ -99,13 +99,13 @@
     <string name="events">Termine (Geburtstage, Jahrestage)</string>
     <string name="notes">Notizen</string>
     <string name="organization">Organisation</string>
-    <string name="websites">Websites</string>
+    <string name="websites">Webseiten</string>
     <string name="groups">Gruppen</string>
     <string name="contact_source">Kontaktquelle</string>
 
     <!-- FAQ -->
     <string name="faq_1_title">Ich möchte die sichtbaren Kontaktfelder ändern. Kann ich das machen?</string>
-    <string name="faq_1_text">Ja, alles, was Sie machen müssen ist folgendes: Gehen Sie zu Einstellungen -> Bearbeite sichtbare Kontaktfelder. Hier können die sichtbaren Felder bearbeitet werden. Einige sind standardmäßig deaktiviert, weshalb hier neue gefunden werden können.</string>
+    <string name="faq_1_text">Ja, alles, was Sie tun müssen ist folgendes: Gehen Sie zu Einstellungen -> Bearbeite sichtbare Kontaktfelder. Hier können die sichtbaren Felder ausgewählt werden. Einige sind standardmäßig deaktiviert, weshalb hier neue gefunden werden können.</string>
 
     <!-- Strings displayed only on Google Playstore. Optional, but good to have -->
     <!-- Short description has to have less than 80 chars -->


### PR DESCRIPTION
removes some wrong translations and improves some correct, but unfavorable strings.

Replaces "Schlichte Kontakte" with "Simple Kontakte" - why?

* "Simple Contacts" translates to "Schlichte Kontakte" or "Einfache Kontakte" in German
* "Simple Kontakte" is a korrekt, if rare translation
* keeping "Simple" is good for brand recognition across multiple languages and makes it easier for people to find the app and the app suite online.