### PR TITLE
fix #231, import photos that contain other vCard tokens

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/helpers/VcfImporter.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/helpers/VcfImporter.kt
@@ -73,6 +73,9 @@ class VcfImporter(val activity: SimpleActivity) {
                             isGettingPhoto = false
                         }
                         continue
+                    } else if (isGettingPhoto) {
+                        currentPhotoString.append(line)
+                        continue
                     } else if (line.startsWith('\t') && isGettingName) {
                         currentNameString.append(line.trimStart('\t'))
                         isGettingName = false
@@ -105,7 +108,6 @@ class VcfImporter(val activity: SimpleActivity) {
                         line.toUpperCase().startsWith(TITLE) -> addJobPosition(line.substring(TITLE.length))
                         line.toUpperCase().startsWith(URL) -> addWebsite(line.substring(URL.length))
                         line.toUpperCase() == END_VCARD -> saveContact(targetContactSource)
-                        isGettingPhoto -> currentPhotoString.append(line.trim())
                     }
                 }
             }


### PR DESCRIPTION
Simple but rather hackish fix for #231.

A better approach would probably be to clean up and restructure the whole if-else-when block of the importer, as there probably lurk some more undiscovered bugs in it. E.g. the next condition `line.startsWith('\t') && isGettingName` will never be true as the line is already trimmed. If it's ok, i'd give it a try in the next few days.