### PR TITLE
add and balance spacing around UI elements

### DIFF
--- a/app/src/main/res/layout/activity_insert_edit_contact.xml
+++ b/app/src/main/res/layout/activity_insert_edit_contact.xml
@@ -11,7 +11,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="?attr/selectableItemBackground"
-        android:paddingEnd="@dimen/activity_margin">
+        android:paddingEnd="@dimen/activity_margin"
+        android:paddingStart="@dimen/activity_margin">
 
         <ImageView
             android:id="@+id/new_contact_tmb"

--- a/app/src/main/res/layout/item_add_favorite_with_number.xml
+++ b/app/src/main/res/layout/item_add_favorite_with_number.xml
@@ -13,7 +13,8 @@
         android:id="@+id/contact_holder"
         android:layout_width="match_parent"
         android:layout_height="@dimen/contact_item_height"
-        android:paddingEnd="@dimen/normal_margin">
+        android:paddingEnd="@dimen/normal_margin"
+        android:paddingStart="@dimen/normal_margin">
 
         <ImageView
             android:id="@+id/contact_tmb"

--- a/app/src/main/res/layout/item_add_favorite_without_number.xml
+++ b/app/src/main/res/layout/item_add_favorite_without_number.xml
@@ -13,7 +13,8 @@
         android:id="@+id/contact_holder"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingEnd="@dimen/normal_margin">
+        android:paddingEnd="@dimen/normal_margin"
+        android:paddingStart="@dimen/normal_margin">
 
         <ImageView
             android:id="@+id/contact_tmb"

--- a/app/src/main/res/layout/item_contact_with_number.xml
+++ b/app/src/main/res/layout/item_contact_with_number.xml
@@ -15,6 +15,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/contact_item_with_number_height"
         android:paddingTop="@dimen/tiny_margin"
+        android:paddingStart="@dimen/activity_margin"
         android:paddingEnd="@dimen/activity_margin">
 
         <ImageView

--- a/app/src/main/res/layout/item_contact_without_number.xml
+++ b/app/src/main/res/layout/item_contact_without_number.xml
@@ -14,6 +14,7 @@
         android:id="@+id/contact_holder"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_margin"
         android:paddingEnd="@dimen/activity_margin">
 
         <ImageView

--- a/app/src/main/res/layout/item_edit_address.xml
+++ b/app/src/main/res/layout/item_edit_address.xml
@@ -27,7 +27,7 @@
         android:background="?attr/selectableItemBackground"
         android:gravity="center"
         android:paddingStart="@dimen/medium_margin"
-        android:paddingRight="@dimen/medium_margin"
+        android:paddingEnd="@dimen/medium_margin"
         android:text="@string/address"
         android:textSize="@dimen/bigger_text_size"/>
 

--- a/app/src/main/res/layout/item_filter_contact_source.xml
+++ b/app/src/main/res/layout/item_filter_contact_source.xml
@@ -13,6 +13,7 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/medium_margin"
         android:clickable="false"
-        android:paddingStart="@dimen/small_margin"/>
+        android:paddingStart="@dimen/small_margin"
+        android:paddingEnd="@dimen/small_margin"/>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/item_group.xml
+++ b/app/src/main/res/layout/item_group.xml
@@ -14,6 +14,7 @@
         android:id="@+id/group_holder"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_margin"
         android:paddingEnd="@dimen/activity_margin">
 
         <ImageView

--- a/app/src/main/res/layout/item_textview.xml
+++ b/app/src/main/res/layout/item_textview.xml
@@ -5,7 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/activity_margin"
+    android:layout_marginEnd="@dimen/activity_margin"
     android:background="?attr/selectableItemBackground"
     android:paddingBottom="@dimen/activity_margin"
     android:paddingStart="@dimen/medium_margin"
+    android:paddingEnd="@dimen/medium_margin"
     android:paddingTop="@dimen/activity_margin"/>


### PR DESCRIPTION
Right now many elements have spacing on just one side and not the other. This balances those out.

It also adds a bit of space near the screen borders so icons aren't hitting the edges of the screen (I tried a few other contacts apps and they all have a similar or greater amount of padding, so this seems to be a standard design choice). The screen-edge spacing is also useful on curved screens to keep contact images from warping around the edge on the left and right sides.

Example of screen padding:

Before:
![](https://user-images.githubusercontent.com/3249268/59544609-a86e0580-8f02-11e9-9531-5360232fdad7.jpg)

After:
![](https://user-images.githubusercontent.com/3249268/59544611-aa37c900-8f02-11e9-8a29-b251258a4d15.jpg)