### PR TITLE
Dutch

### DIFF
--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -21,7 +21,7 @@
     <string name="set_as_default">Als standaard instellen</string>
 
     <!-- Placeholders -->
-    <string name="no_contacts_found">Geen contacten .</string>
+    <string name="no_contacts_found">Geen contacten gevonden.</string>
     <string name="no_contacts_with_emails">Geen contacten met e-mailadressen gevonden</string>
     <string name="no_contacts_with_phone_numbers">Geen contacten met telefoonnummers gevonden</string>
 


### PR DESCRIPTION
Any reason why "gevonden" was removed? String length? Otherwise "Geen contacten." (without the space befor the period 😜) would be fine, too.