### PR TITLE
[RFC] Draft attempt to handle phone-local contacts public to all apps

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/extensions/Activity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/extensions/Activity.kt
@@ -54,7 +54,7 @@ fun SimpleActivity.startCall(contact: Contact) {
     }
 }
 
-fun SimpleActivity.showContactSourcePicker(currentSource: String, callback: (newSource: String) -> Unit) {
+fun SimpleActivity.showContactSourcePicker(currentSource: String?, callback: (newSource: String) -> Unit) {
     ContactsHelper(this).getContactSources {
         val ignoredTypes = arrayListOf(
                 SIGNAL_PACKAGE,

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/helpers/ContactsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/helpers/ContactsHelper.kt
@@ -117,14 +117,14 @@ class ContactsHelper(val context: Context) {
             cursor = context.contentResolver.query(uri, projection, null, null, null)
             if (cursor?.moveToFirst() == true) {
                 do {
-                    val name = cursor.getStringValue(ContactsContract.RawContacts.ACCOUNT_NAME) ?: ""
-                    val type = cursor.getStringValue(ContactsContract.RawContacts.ACCOUNT_TYPE) ?: ""
+                    val name = cursor.getStringValue(ContactsContract.RawContacts.ACCOUNT_NAME)
+                    val type = cursor.getStringValue(ContactsContract.RawContacts.ACCOUNT_TYPE)
                     var publicName = name
                     if (type == TELEGRAM_PACKAGE) {
                         publicName += " (${context.getString(R.string.telegram)})"
                     }
 
-                    val source = ContactSource(name, type, publicName)
+                    val source = ContactSource(name, type, publicName ?: "NULL")
                     sources.add(source)
                 } while (cursor.moveToNext())
             }
@@ -890,14 +890,14 @@ class ContactsHelper(val context: Context) {
         }
 
         val contentResolverAccounts = getContentResolverAccounts().filter {
-            it.name.isNotEmpty() && it.type.isNotEmpty() && !accounts.contains(Account(it.name, it.type))
+            !accounts.contains(Account(it.name, it.type))
         }
         sources.addAll(contentResolverAccounts)
 
         return sources
     }
 
-    private fun getContactSourceType(accountName: String) = getDeviceContactSources().firstOrNull { it.name == accountName }?.type ?: ""
+    private fun getContactSourceType(accountName: String?) = getDeviceContactSources().first { it.name == accountName }.type
 
     private fun getContactProjection() = arrayOf(
             ContactsContract.Data.MIMETYPE,

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/models/Contact.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/models/Contact.kt
@@ -11,7 +11,7 @@ import com.simplemobiletools.contacts.pro.helpers.SMT_PRIVATE
 
 data class Contact(var id: Int, var prefix: String, var firstName: String, var middleName: String, var surname: String, var suffix: String, var nickname: String,
                    var photoUri: String, var phoneNumbers: ArrayList<PhoneNumber>, var emails: ArrayList<Email>, var addresses: ArrayList<Address>,
-                   var events: ArrayList<Event>, var source: String, var starred: Int, var contactId: Int, var thumbnailUri: String, var photo: Bitmap?, var notes: String,
+                   var events: ArrayList<Event>, var source: String?, var starred: Int, var contactId: Int, var thumbnailUri: String, var photo: Bitmap?, var notes: String,
                    var groups: ArrayList<Group>, var organization: Organization, var websites: ArrayList<String>, var IMs: ArrayList<IM>) :
         Comparable<Contact> {
     companion object {
@@ -109,7 +109,7 @@ data class Contact(var id: Int, var prefix: String, var firstName: String, var m
 
     fun getStringToCompare(): String {
         return copy(id = 0, prefix = "", firstName = getNameToDisplay().toLowerCase(), middleName = "", surname = "", suffix = "", nickname = "", photoUri = "",
-                phoneNumbers = ArrayList(), emails = ArrayList(), events = ArrayList(), source = "", addresses = ArrayList(), starred = 0, contactId = 0,
+                phoneNumbers = ArrayList(), emails = ArrayList(), events = ArrayList(), source = null, addresses = ArrayList(), starred = 0, contactId = 0,
                 thumbnailUri = "", notes = "", groups = ArrayList(), websites = ArrayList(), organization = Organization("", ""), IMs = ArrayList()).toString()
     }
 

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/models/ContactSource.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/models/ContactSource.kt
@@ -2,10 +2,16 @@ package com.simplemobiletools.contacts.pro.models
 
 import com.simplemobiletools.contacts.pro.helpers.SMT_PRIVATE
 
-data class ContactSource(var name: String, var type: String, var publicName: String) {
+data class ContactSource(var name: String?, var type: String?, var publicName: String) {
     fun getFullIdentifier(): String {
         return if (type == SMT_PRIVATE) {
             type
+        } else if (name == null && type == null) {
+            ":"
+        } else if (name == null && type != null) {
+            ":$type"
+        } else if (name != null && type == null) {
+            "$name:"
         } else {
             "$name:$type"
         }


### PR DESCRIPTION
This is a draft patch that I have **not** tested. (Once I have a working setup for building apps I may test this.) Please see the commit message for details.

I am opening this:
- So to receive early feedback. Once I receive some feedback, I plan to close this draft PR.
- So to share with any developers looking into contact-visibility issues (https://github.com/SimpleMobileTools/Simple-Contacts/issues/370, https://github.com/SimpleMobileTools/Simple-Contacts/issues/491, https://github.com/SimpleMobileTools/Simple-Contacts/issues/518) an area of exploration.

----

From https://github.com/SimpleMobileTools/Simple-Contacts/issues/370#issue-413698567 :

> Updating to version 6.3.0, only the "not visible by other apps" contacts are displayed.
> The option to display "public" contacts (under filters) is gone.
> Same problem with 6.2.0.
> Downgrading two steps back to version 6.1.2 bring back the "public" contacts.

So I looked at [the differences between 6.1.2 and 6.2.0](https://github.com/SimpleMobileTools/Simple-Contacts/compare/6.1.2...6.2.0). The relevant changes seem related to `LOCAL_ACCOUNT_TYPE` and `localAccountTypes`.

In the current codebase I noticed the default empty string `""` in case account type or name are null. Having read about Android 11 null value for these fields, and having experimented with actual account type and name on an Android One device, I decided to draft this patch.
