### PR TITLE
Fix contacts not refreshing when search bar is open

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/MainActivity.kt
@@ -52,6 +52,7 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
 
     private var isSearchOpen = false
     private var searchMenuItem: MenuItem? = null
+    private var searchQuery = ""
     private var werePermissionsHandled = false
     private var isFirstResume = true
     private var isGettingContacts = false
@@ -229,6 +230,7 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
 
                 override fun onQueryTextChange(newText: String): Boolean {
                     if (isSearchOpen) {
+                        searchQuery = newText
                         getCurrentFragment()?.onSearchQueryChanged(newText)
                     }
                     return true
@@ -540,7 +542,7 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
     }
 
     override fun refreshContacts(refreshTabsMask: Int) {
-        if (isDestroyed || isFinishing || isGettingContacts || isSearchOpen) {
+        if (isDestroyed || isFinishing || isGettingContacts) {
             return
         }
 
@@ -571,6 +573,10 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
                     groups_fragment.skipHashComparing = true
                 }
                 groups_fragment?.refreshContacts(contacts)
+            }
+
+            if (isSearchOpen) {
+                getCurrentFragment()?.onSearchQueryChanged(searchQuery)
             }
         }
     }


### PR DESCRIPTION
Addresses #698.

Before, if you opened the search bar and went on to add a contact, the new contact wasn't shown.
With this change, contacts will be refreshed, and the previous search query will be reapplied.

I tested different scenarios – and nothing seemed to be broken after this change.
However, if you know that there might be something tricky, let me know.