### PR TITLE
Fixed text alignment for ringtone name

### DIFF
--- a/app/src/main/res/layout/activity_edit_contact.xml
+++ b/app/src/main/res/layout/activity_edit_contact.xml
@@ -403,7 +403,7 @@
                 android:layout_centerVertical="true"
                 android:layout_marginTop="@dimen/normal_margin"
                 android:layout_marginEnd="@dimen/activity_margin"
-                android:layout_toEndOf="@+id/contact_notes_image"
+                android:layout_toEndOf="@+id/contact_ringtone_image"
                 android:background="?attr/selectableItemBackground"
                 android:gravity="center_vertical"
                 android:minHeight="@dimen/contact_icons_size"


### PR DESCRIPTION
Hi,

Ringtone name in contact details editing was overlapping with its icon. I've fixed it.

**Before:**
![image](https://user-images.githubusercontent.com/85929121/131653562-73ad6421-e42c-4aa3-85fe-dd0f6b762100.png)

**After:**
![image](https://user-images.githubusercontent.com/85929121/131654072-424608df-cfcc-475a-93e6-495e59f4b540.png)