### PR TITLE
Fixed group count while changing name (#589)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/dialogs/RenameGroupDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/dialogs/RenameGroupDialog.kt
@@ -36,6 +36,7 @@ class RenameGroupDialog(val activity: BaseSimpleActivity, val group: Group, val 
                             }
 
                             group.title = newTitle
+                            group.contactsCount = 0
                             ensureBackgroundThread {
                                 if (group.isPrivateSecretGroup()) {
                                     activity.groupsDB.insertOrUpdate(group)


### PR DESCRIPTION
Hi,

I've fixed the issue, that groups list was showing wrong items count in a group after renaming it. I've found out, that after changing a group name, the function for counting group members was called once again, even though the group had already counted group members. To avoid it, I'm resetting contacts count while changing the name, since the app will recount them once again.

**Before:**

https://user-images.githubusercontent.com/85929121/137363250-d6878a32-3af0-432f-b1f8-a9cb253b6cc4.mp4

**After:**

https://user-images.githubusercontent.com/85929121/137363292-32c4e7a7-b9b3-45a4-946d-f59c3cf9bf79.mp4

