### PR TITLE
Fixed accessing phone contacts

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/EditContactActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/EditContactActivity.kt
@@ -644,7 +644,7 @@ class EditContactActivity : ContactActivity() {
     private fun setupContactSource() {
         originalContactSource = contact!!.source
         getPublicContactSource(contact!!.source) {
-            contact_source.text = it
+            contact_source.text = if (it == "") getString(R.string.phone_storage) else it
         }
     }
 
@@ -653,7 +653,7 @@ class EditContactActivity : ContactActivity() {
         originalContactSource = if (hasContactPermissions()) config.lastUsedContactSource else SMT_PRIVATE
         contact = getEmptyContact()
         getPublicContactSource(contact!!.source) {
-            contact_source.text = it
+            contact_source.text = if (it == "") getString(R.string.phone_storage) else it
         }
 
         // if the last used contact source is not available anymore, use the first available one. Could happen at ejecting SIM card
@@ -663,7 +663,7 @@ class EditContactActivity : ContactActivity() {
                 originalContactSource = sourceNames.first()
                 contact?.source = originalContactSource
                 getPublicContactSource(contact!!.source) {
-                    contact_source.text = it
+                    contact_source.text = if (it == "") getString(R.string.phone_storage) else it
                 }
             }
         }
@@ -916,7 +916,7 @@ class EditContactActivity : ContactActivity() {
         showContactSourcePicker(contact!!.source) {
             contact!!.source = if (it == getString(R.string.phone_storage_hidden)) SMT_PRIVATE else it
             getPublicContactSource(it) {
-                contact_source.text = it
+                contact_source.text = if (it == "") getString(R.string.phone_storage) else it
             }
         }
     }

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ViewContactActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ViewContactActivity.kt
@@ -536,7 +536,7 @@ class ViewContactActivity : ContactActivity() {
 
             for ((key, value) in sources) {
                 layoutInflater.inflate(R.layout.item_view_contact_source, contact_sources_holder, false).apply {
-                    contact_source.text = value
+                    contact_source.text = if (value == "") getString(R.string.phone_storage) else value
                     contact_source.copyOnLongClick(value)
                     contact_sources_holder.addView(this)
 

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/dialogs/ImportContactsDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/dialogs/ImportContactsDialog.kt
@@ -42,7 +42,7 @@ class ImportContactsDialog(val activity: SimpleActivity, val path: String, priva
                 activity.showContactSourcePicker(targetContactSource) {
                     targetContactSource = if (it == activity.getString(R.string.phone_storage_hidden)) SMT_PRIVATE else it
                     activity.getPublicContactSource(it) {
-                        import_contacts_title.text = it
+                        import_contacts_title.text = if (it == "") activity.getString(R.string.phone_storage) else it
                     }
                 }
             }

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/helpers/ContactsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/helpers/ContactsHelper.kt
@@ -807,6 +807,10 @@ class ContactsHelper(val context: Context) {
         }
         sources.addAll(contentResolverAccounts)
 
+        if (!sources.any { it.type.startsWith("com.google") || it.type.startsWith("com.android") || it.type.startsWith("com.qualcomm") }) {
+            sources.add(ContactSource("", "", context.getString(R.string.phone_storage)))
+        }
+
         return sources
     }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">العنوان</string>
     <string name="inserting">إضافة…</string>
     <string name="updating">تحديث…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">ذاكرة الهاتف (غير مرئية من قبل التطبيقات الأخرى)</string>
     <string name="company">الشركة</string>
     <string name="job_position">الوظيفة</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Ünvan</string>
     <string name="inserting">Daxil edilir…</string>
     <string name="updating">Yenilənir…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefon yaddaşı (digər tətbiqlərə görünmür)</string>
     <string name="company">Şirkət</string>
     <string name="job_position">İş vəziyyəti</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Adresa</string>
     <string name="inserting">Vytváří se…</string>
     <string name="updating">Upravuje se…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Úložiště telefonu (neviditelné pro ostatní apky)</string>
     <string name="company">Firma</string>
     <string name="job_position">Pracovní pozice</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Cyfeiriad</string>
     <string name="inserting">Yn gosod…</string>
     <string name="updating">Yn diweddaru…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Storfa ddyfais (dim i\'w weld gan apiau eraill)</string>
     <string name="company">Cwmni</string>
     <string name="job_position">Swydd</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Adresse</string>
     <string name="inserting">Indsætter…</string>
     <string name="updating">Opdaterer…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefon lager (ikke synlig for andre apps)</string>
     <string name="company">Firma</string>
     <string name="job_position">Stilling</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Adresse</string>
     <string name="inserting">Einfügen…</string>
     <string name="updating">Aktualisiere…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Gerätespeicher (nicht sichtbar für andere Apps)</string>
     <string name="company">Unternehmen</string>
     <string name="job_position">Arbeitsstelle</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Διεύθυνση</string>
     <string name="inserting">Εισαγωγή…</string>
     <string name="updating">Ενημέρωση…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Μνήμη τηλεφώνου (κρυφές από άλλες εφαρμογές)</string>
     <string name="company">Εταιρεία</string>
     <string name="job_position">Θέση Εργασίας</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Dirección</string>
     <string name="inserting">Insertando…</string>
     <string name="updating">Actualizando…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Almacenamiento del teléfono (No visible para otras aplicaciones)</string>
     <string name="company">Compañía</string>
     <string name="job_position">Puesto de trabajo</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Helbidea</string>
     <string name="inserting">Txertatzen…</string>
     <string name="updating">Eguneratzen…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefono memoria (beste aplikazioentzat ikustezina)</string>
     <string name="company">Enpresa</string>
     <string name="job_position">Lanpostua</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Osoite</string>
     <string name="inserting">Sijoitetaan...</string>
     <string name="updating">Päivitetään...</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Puhelimen muisti (piilotettu muilta sovelluksilta)</string>
     <string name="company">Yritys</string>
     <string name="job_position">Ammatti</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Adresse</string>
     <string name="inserting">Insertion…</string>
     <string name="updating">Actualisation…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Mémoire du téléphone (invisible pour les autres applis)</string>
     <string name="company">Entreprise</string>
     <string name="job_position">Poste</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Endereço</string>
     <string name="inserting">A inserir…</string>
     <string name="updating">A atualizar…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Armazenamento do telefone (não visível por outras alicações)</string>
     <string name="company">Organização</string>
     <string name="job_position">Cargo</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Address</string>
     <string name="inserting">Inserting…</string>
     <string name="updating">Updating…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Phone storage (not visible by other apps)</string>
     <string name="company">Company</string>
     <string name="job_position">Job position</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Adresa</string>
     <string name="inserting">Dodavanje…</string>
     <string name="updating">Ažuriranje…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Pohrana na telefonu (nije vidljiva drugim aplikacijama))</string>
     <string name="company">Tvrtka</string>
     <string name="job_position">Radno mjesto</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Cím</string>
     <string name="inserting">Hozzáadás…</string>
     <string name="updating">Módosítás…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefon tárhelye (többi alkalmazás számára nem látható)</string>
     <string name="company">Cégnév</string>
     <string name="job_position">Munkakör</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Alamat</string>
     <string name="inserting">Menyimpan…</string>
     <string name="updating">Memperbarui…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Penyimpanan telepon (tidak terlihat oleh aplikasi lain)</string>
     <string name="company">Perusahaan</string>
     <string name="job_position">Jabatan</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Indirizzo</string>
     <string name="inserting">Inserimento in corso…</string>
     <string name="updating">Aggiornamento in corso…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Memoria del telefono (non visibile alle altre applicazioni)</string>
     <string name="company">Società</string>
     <string name="job_position">Posizione lavorativa</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">住所</string>
     <string name="inserting">挿入中…</string>
     <string name="updating">更新中…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">内部ストレージ (他のアプリからは表示されません)</string>
     <string name="company">会社</string>
     <string name="job_position">役職</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">주소</string>
     <string name="inserting">등록중…</string>
     <string name="updating">수정중…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Phone storage (not visible by other apps)</string>
     <string name="company">Company</string>
     <string name="job_position">Job position</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Adresas</string>
     <string name="inserting">Įterpiama…</string>
     <string name="updating">Atnaujinama…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefono atmintis (nematoma kitų programėlių)</string>
     <string name="company">Company</string>
     <string name="job_position">Job position</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">വിലാസം</string>
     <string name="inserting">ചേർക്കുന്നു…</string>
     <string name="updating">പുതുക്കുന്നു…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">ഫോൺ സ്റ്റോറേജ് (മറ്റ് അപ്ലിക്കേഷനുകൾക്ക് ദൃശ്യമല്ല)</string>
     <string name="company">കമ്പനി</string>
     <string name="job_position">ഉദ്യോഗ സ്ഥാനം</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Adresse</string>
     <string name="inserting">Legger til …</string>
     <string name="updating">Oppdaterer …</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefonlager (ikke synlig for andre programmer)</string>
     <string name="company">Firma</string>
     <string name="job_position">Stilling</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Adres</string>
     <string name="inserting">Toevoegen…</string>
     <string name="updating">Updaten…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefoonopslag (niet zichtbaar voor andere apps)</string>
     <string name="company">Bedrijf</string>
     <string name="job_position">Titel</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Adres</string>
     <string name="inserting">Dodawanie…</string>
     <string name="updating">Aktualizowanie…</string>
+    <string name="phone_storage">Pamięć telefonu</string>
     <string name="phone_storage_hidden">Pamięć telefonu (niewidoczne dla innych aplikacji)</string>
     <string name="company">Firma</string>
     <string name="job_position">Stanowisko</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Endereço</string>
     <string name="inserting">Inserindo…</string>
     <string name="updating">Atualizando…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Armazenamento do telefone (não visível por outros aplicativos)</string>
     <string name="company">Empresa</string>
     <string name="job_position">Cargo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Endereço</string>
     <string name="inserting">A inserir…</string>
     <string name="updating">A atualizar…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Armazenamento do telefone (não visível por outras alicações)</string>
     <string name="company">Organização</string>
     <string name="job_position">Cargo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Адрес</string>
     <string name="inserting">Добавление…</string>
     <string name="updating">Обновление…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Память устройства (не видна другим приложениям)</string>
     <string name="company">Организация</string>
     <string name="job_position">Должность</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Adresa</string>
     <string name="inserting">Vytvára sa…</string>
     <string name="updating">Upravuje sa…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Úložisko mobilu (neviditeľné pre ostatné apky)</string>
     <string name="company">Firma</string>
     <string name="job_position">Pracovná pozícia</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -4,7 +4,7 @@
     <string name="address">Adresa</string>
     <string name="inserting">Vytvára sa…</string>
     <string name="updating">Upravuje sa…</string>
-    <string name="phone_storage">Phone storage</string>
+    <string name="phone_storage">Úložisko mobilu</string>
     <string name="phone_storage_hidden">Úložisko mobilu (neviditeľné pre ostatné apky)</string>
     <string name="company">Firma</string>
     <string name="job_position">Pracovná pozícia</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Adress</string>
     <string name="inserting">Lägger till…</string>
     <string name="updating">Uppdaterar…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefonens lagringsutrymme (inte synligt för andra appar)</string>
     <string name="company">Företag</string>
     <string name="job_position">Befattning</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Adres</string>
     <string name="inserting">Ekleniyor…</string>
     <string name="updating">Güncelleniyor…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Telefon belleği (diğer uygulamalar tarafından görülmez)</string>
     <string name="company">Şirket</string>
     <string name="job_position">İş pozisyonu</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">Адреса</string>
     <string name="inserting">Триває додавання…</string>
     <string name="updating">Триває оновлення…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Пам\'ять пристрою (прихована від інших додатків)</string>
     <string name="company">Компанія</string>
     <string name="job_position">Посада</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">地址</string>
     <string name="inserting">添加中…</string>
     <string name="updating">更新中…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">手机空间 (其他程序不可见)</string>
     <string name="company">公司</string>
     <string name="job_position">职位</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -4,6 +4,7 @@
     <string name="address">地址</string>
     <string name="inserting">添加中…</string>
     <string name="updating">更新中…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">手機空間 (其他程式不可見)</string>
     <string name="company">公司</string>
     <string name="job_position">職位</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="address">Address</string>
     <string name="inserting">Inserting…</string>
     <string name="updating">Updating…</string>
+    <string name="phone_storage">Phone storage</string>
     <string name="phone_storage_hidden">Phone storage (not visible by other apps)</string>
     <string name="company">Company</string>
     <string name="job_position">Job position</string>


### PR DESCRIPTION
Hi,

I've fixed the problem that on some phones (including Android 12 emulator) Simple Contacts couldn't access contacts stored by default contacts app:
- via git bisect I've found that issue was introduced by this commit: <https://github.com/SimpleMobileTools/Simple-Contacts/commit/4dcb46c7abe8e991bc3ad8bcd670bbb1302be6d0>
- it appears that some phones doesn't create an account for contacts, so we need to add an empty account as a contact source
- since it's empty and doesn't have a name, I'm adding it a public name "Phone storage"
- I think we shouldn't show this entry if someone's phone is properly saving contacts under an account. From what I've found (e.g. [here](https://android.stackexchange.com/questions/133456/missing-account-name-and-app-icon-in-account-entry-nothingtoseehere-account)), native contact apps are starting with `com.google`, `com.android` (e.g. on OnePlus it's `com.android.localphone` and it gives a name `PHONE`) or `com.qualcomm`, so I'm checking if any of these are present
- it has to be done instead of checking for empty sources list (like it was in the mentioned commit), because if someone has Signal or similar app, it would enter as a contact source, and we wouldn't be able to get all contacts
- generally there are a few issues that are mentioning that, so I'm writing there those that I'm 100% sure that this fix addresses:
  - fixes #623 
  - fixes #700 
  - fixes #579 
  - fixes #575 

**Before:**

https://user-images.githubusercontent.com/85929121/145075504-365965d3-f97b-468e-af7d-332b26c78fc8.mp4

**After:**

https://user-images.githubusercontent.com/85929121/145075527-8ae5439f-52ec-43f7-9838-84d24bd76a58.mp4

