### PR TITLE
Fixed problems with ringtone selection (#756)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ContactActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ContactActivity.kt
@@ -24,6 +24,7 @@ import com.bumptech.glide.request.target.Target
 import com.simplemobiletools.commons.dialogs.ConfirmationDialog
 import com.simplemobiletools.commons.dialogs.RadioGroupDialog
 import com.simplemobiletools.commons.extensions.*
+import com.simplemobiletools.commons.helpers.SILENT
 import com.simplemobiletools.commons.helpers.letterBackgroundColors
 import com.simplemobiletools.commons.models.RadioItem
 import com.simplemobiletools.contacts.pro.R
@@ -241,12 +242,14 @@ abstract class ContactActivity : SimpleActivity() {
         return bitmap
     }
 
-    protected fun getDefaultRingtoneUri() = RingtoneManager.getActualDefaultRingtoneUri(this, RingtoneManager.TYPE_RINGTONE)
+    protected fun getDefaultRingtoneUri() = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_RINGTONE)
 
     protected fun getRingtonePickerIntent(): Intent {
         val defaultRingtoneUri = getDefaultRingtoneUri()
-        val currentRingtoneUri = if (contact!!.ringtone != null) {
+        val currentRingtoneUri = if (contact!!.ringtone != null && contact!!.ringtone!!.isNotEmpty()) {
             Uri.parse(contact!!.ringtone)
+        } else if (contact!!.ringtone?.isNotEmpty() == false) {
+            null
         } else {
             defaultRingtoneUri
         }

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ContactActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ContactActivity.kt
@@ -24,7 +24,6 @@ import com.bumptech.glide.request.target.Target
 import com.simplemobiletools.commons.dialogs.ConfirmationDialog
 import com.simplemobiletools.commons.dialogs.RadioGroupDialog
 import com.simplemobiletools.commons.extensions.*
-import com.simplemobiletools.commons.helpers.SILENT
 import com.simplemobiletools.commons.helpers.letterBackgroundColors
 import com.simplemobiletools.commons.models.RadioItem
 import com.simplemobiletools.contacts.pro.R

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/EditContactActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/EditContactActivity.kt
@@ -1321,7 +1321,7 @@ class EditContactActivity : ContactActivity() {
     }
 
     override fun systemRingtoneSelected(uri: Uri?) {
-        contact!!.ringtone = uri?.toString()
+        contact!!.ringtone = uri?.toString() ?: ""
         val contactRingtone = RingtoneManager.getRingtone(this, uri)
         contact_ringtone.text = contactRingtone.getTitle(this)
     }

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ViewContactActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ViewContactActivity.kt
@@ -615,7 +615,7 @@ class ViewContactActivity : ContactActivity() {
             val ringtone = contact!!.ringtone
             if (ringtone?.isEmpty() == true) {
                 contact_ringtone.text = getString(R.string.no_sound)
-            } else if (ringtone?.isNotEmpty() == true) {
+            } else if (ringtone?.isNotEmpty() == true && ringtone != getDefaultRingtoneUri().toString()) {
                 if (ringtone == SILENT) {
                     contact_ringtone.text = getString(R.string.no_sound)
                 } else {
@@ -708,7 +708,7 @@ class ViewContactActivity : ContactActivity() {
     override fun systemRingtoneSelected(uri: Uri?) {
         val contactRingtone = RingtoneManager.getRingtone(this, uri)
         contact_ringtone.text = contactRingtone.getTitle(this)
-        ringtoneUpdated(uri.toString())
+        ringtoneUpdated(uri?.toString() ?: "")
     }
 
     private fun ringtoneUpdated(path: String?) {

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/helpers/ContactsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/helpers/ContactsHelper.kt
@@ -1097,7 +1097,7 @@ class ContactsHelper(val context: Context) {
                 val uri = Uri.withAppendedPath(Contacts.CONTENT_URI, contact.contactId.toString())
                 val contentValues = ContentValues(2)
                 contentValues.put(Contacts.STARRED, contact.starred)
-                contentValues.put(Contacts.CUSTOM_RINGTONE, contact.ringtone ?: "")
+                contentValues.put(Contacts.CUSTOM_RINGTONE, contact.ringtone)
                 context.contentResolver.update(uri, contentValues, null, null)
             } catch (e: Exception) {
                 context.showErrorToast(e)


### PR DESCRIPTION
Fixes #756. List of fixes:
- When changing to "no sound" from contact view, it no longer shows "null".
- Ringtone picker now shows selected radio button for no sound and default.
- When changing to default, now it stores it as a default ringtone, not a particular sound that is currently selected as default.
- If default is selected, now it doesn't show on contact view.
- Also additional, not mentioned in the issue: when there was a default ringtone selected and someone edited anything in contact, it changed the ringtone to none. The fix was related to what has been listed before, so I also fixed it.

**Before:**

https://user-images.githubusercontent.com/85929121/147466635-fc277604-44d1-4c33-8374-8311ed014fc7.mp4

**After:**

https://user-images.githubusercontent.com/85929121/147466650-dc89fd02-31ee-4bd4-963d-0209edd59931.mp4
