### PR TITLE
Fixed opening private contacts not working in Simple Dialer

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/helpers/LocalContactsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/helpers/LocalContactsHelper.kt
@@ -136,7 +136,7 @@ class LocalContactsHelper(val context: Context) {
         }
 
         return getEmptyLocalContact().apply {
-            id = if (contact.id == 0) null else contact.id
+            id = if (contact.id <= FIRST_CONTACT_ID) null else contact.id
             prefix = contact.prefix
             firstName = contact.firstName
             middleName = contact.middleName


### PR DESCRIPTION
Hi,

I've noticed a bug that after changing contact source from `Phone storage` to `Phone storage (not visible by other apps)`, the contact won't get ID change, so Simple Dialer won't be able to tell that it's a private contact, therefore it won't open Simple Contacts to show contact details. I've fixed it by assuming, that every ID lower or equal `FIRST_CONTACT_ID` is wrong, and should be regenerated.

**Before:**

https://user-images.githubusercontent.com/85929121/150689548-3a5b6922-fd71-4cf5-8500-ef8a774b8df5.mp4

**After:**

https://user-images.githubusercontent.com/85929121/150689555-33febb47-a56e-440b-8dc0-3d5504e58278.mp4
