### PR TITLE
Removed redundant toast on copying to clipboard

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ViewContactActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ViewContactActivity.kt
@@ -858,7 +858,6 @@ class ViewContactActivity : ContactActivity() {
     private fun View.copyOnLongClick(value: String) {
         setOnLongClickListener {
             copyToClipboard(value)
-            toast(R.string.value_copied_to_clipboard)
             true
         }
     }


### PR DESCRIPTION
Hi,

I've fixed redundant toast while copying field from contact to the clipboard. Before the fix, first it was showing toast with a copied value (defined in `Context.copyToClipboard`) to just a while later display that value has been copied to clipboard (defined in `copyOnLongClick`). Fix removes the second one.