### PR TITLE
Fix recreation of activity and improve filter menu visibility

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/MainActivity.kt
@@ -107,7 +107,7 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
 
         if (storedShowTabs != config.showTabs) {
             config.lastUsedViewPagerPage = 0
-            System.exit(0)
+            setupTabs()
             return
         }
 

--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/MainActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/MainActivity.kt
@@ -107,7 +107,8 @@ class MainActivity : SimpleActivity(), RefreshContactsListener {
 
         if (storedShowTabs != config.showTabs) {
             config.lastUsedViewPagerPage = 0
-            setupTabs()
+            finish()
+            startActivity(intent)
             return
         }
 


### PR DESCRIPTION
fix #896 

Summary:
Earlier there were condition ```system.exit``` which was cause issue so now we are setting up the tabs again.