### PR TITLE
Fixed default number indicator (#939)

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ViewContactActivity.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/contacts/pro/activities/ViewContactActivity.kt
@@ -351,7 +351,7 @@ class ViewContactActivity : ContactActivity() {
             val duplicateContactsDefaultNumbers = duplicateContacts.flatMap { it.phoneNumbers }.filter { it.isPrimary }
             val defaultNumbers = (contactDefaultsNumbers + duplicateContactsDefaultNumbers).toSet()
 
-            if (defaultNumbers.size > 1) {
+            if (defaultNumbers.size > 1 && defaultNumbers.distinctBy { it.normalizedNumber }.size > 1) {
                 phoneNumbers.forEach { it.isPrimary = false }
             } else if (defaultNumbers.size == 1) {
                 if (mergeDuplicate) {


### PR DESCRIPTION
Fixes #939

**Before:** 

https://user-images.githubusercontent.com/85929121/217914469-f5beb2f3-6f81-4c46-9b38-d46a8baac684.mp4

**After:**

https://user-images.githubusercontent.com/85929121/217914502-efb5c00a-8a57-4c82-9afc-f779e963c269.mp4

The bug also occurred when numbers were the same, but types were different. It also fixes it.